### PR TITLE
Fixed race condition and increased performance significally

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "apollo": "^2.6.2",
     "graphql": "^14.2.0",
     "graphql-tag": "^2.10.1",
     "jest": "^24.5.0",
@@ -24,6 +23,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "dependencies": {
+    "apollo": "^2.8.3",
     "minimatch": "^3.0.4",
     "ora": "^3.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "minimatch": "^3.0.4",
-    "node-fetch": "^2.3.0"
+    "ora": "^3.4.0"
   }
 }

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,11 +1,13 @@
 const ora = require('ora');
 const cp = require('child_process');
+const path = require('path');
 
 const exec = (name, command) => {
     const spinner = ora(`[ApolloWebpackPlugin] ${name}`).start();
+    const apollo = path.join(__dirname, '..', 'node_modules', '.bin', 'apollo');
 
     return new Promise((resolve, reject) => {
-        cp.exec(`npx apollo@2.6.2 ${command}`, (error, stdout, stderr) => {
+        cp.exec(`${apollo} ${command}`, (error, stdout, stderr) => {
             if (error) {
                 spinner.fail();
                 console.error(error);

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,0 +1,31 @@
+const ora = require('ora');
+const cp = require('child_process');
+
+const exec = (name, command) => {
+    const spinner = ora(`[ApolloWebpackPlugin] ${name}`).start();
+
+    return new Promise((resolve, reject) => {
+        cp.exec(`npx apollo@2.6.2 ${command}`, (error, stdout, stderr) => {
+            if (error) {
+                spinner.fail();
+                console.error(error);
+                return reject();
+            }
+
+            if (stderr) {
+                spinner.fail();
+                console.error(stderr);
+                return reject();
+            }
+
+            if (stdout) {
+                console.log(stdout);
+            }
+
+            spinner.succeed();
+            resolve();
+        });
+    });
+};
+
+module.exports = exec;

--- a/src/fetchSchema.js
+++ b/src/fetchSchema.js
@@ -1,0 +1,18 @@
+const exec = require('./exec');
+
+const fetchSchema = options => {
+    const { endpoint, localSchemaFile, config, header, tag, skipSSLValidation, key } = options;
+    const command = ['service:download'];
+
+    if (localSchemaFile) command.push(localSchemaFile);
+    if (config) command.push(`-c="${config}"`);
+    if (header) command.push(`--header="${header}"`);
+    if (endpoint) command.push(`--endpoint="${endpoint}"`);
+    if (tag) command.push(`-t="${tag}"`);
+    if (skipSSLValidation) command.push(`--skipSSLValidation`);
+    if (key) command.push(`--key="${key}"`);
+
+    return exec('Downloading schema', command.join(' '));
+};
+
+module.exports = fetchSchema;

--- a/src/genTypes.js
+++ b/src/genTypes.js
@@ -1,0 +1,17 @@
+const exec = require('./exec');
+
+const genTypes = options => {
+    const { skipSSLValidation, localSchemaFile, ...restOptions } = options;
+    const timestamps = {};
+
+    const command = Object.keys(restOptions).reduce((acc, option) => {
+        if (option === 'output') return acc;
+        if (restOptions[option] === true) return `${acc} --${option}`;
+
+        return `${acc} --${option}="${restOptions[option]}"`;
+    }, `client:codegen ${restOptions.output ? restOptions.output : ''}`);
+
+    return exec('Generating types', command);
+};
+
+module.exports = genTypes;

--- a/src/index.js
+++ b/src/index.js
@@ -1,35 +1,19 @@
 const { exec } = require('child_process');
 const minimatch = require('minimatch');
-const fetch = require('node-fetch');
 const fs = require('fs');
+const ora = require('ora');
+const fetchSchema = require('./fetchSchema');
+const genTypes = require('./genTypes');
 
 class ApolloCodegenWebpackPlugin {
     constructor(options) {
         this.id = 'ApolloWebpackPlugin';
         this.options = options;
-        this.execCommand = this.execCommand.bind(this);
-        this.genTypes = this.genTypes.bind(this);
-        this.fetchSchema = this.fetchSchema.bind(this);
         this.prevTimestamps = {};
+        this.schemaFetched = false;
     }
 
-    execCommand(command, message = '') {
-        exec(`npx apollo@2.6.2 ${command}`, (error, stdout, stderr) => {
-            if (error) {
-                console.error(error);
-            }
-
-            if (stdout && stdout !== '') {
-                console.log(`${stdout}${message}`);
-            }
-
-            if (stderr && stderr !== '') {
-                console.error(stderr);
-            }
-        });
-    }
-
-    genTypes(compilation) {
+    hasChanged(compilation) {
         const { skipSSLValidation, localSchemaFile, ...options } = this.options;
         const timestamps = {};
         let hasChanged = compilation.fileTimestamps.size === 0; // initial compilation
@@ -48,39 +32,27 @@ class ApolloCodegenWebpackPlugin {
 
         this.prevTimestamps = timestamps;
 
-        const command = Object.keys(options).reduce((acc, option) => {
-            if (option === 'output') return acc;
-            if (options[option] === true) return `${acc} --${option}`;
-
-            return `${acc} --${option}="${options[option]}"`;
-        }, `client:codegen ${options.output ? options.output : ''}`);
-
-        if (hasChanged) {
-            console.log(`[${this.id}] Generating types`);
-            this.execCommand(command, `[${this.id}] Types generated`);
-        }
-    }
-
-    fetchSchema() {
-        const { endpoint, localSchemaFile, config, header, tag, skipSSLValidation, key } = this.options;
-        const command = ['service:download'];
-
-        if (localSchemaFile) command.push(localSchemaFile);
-        if (config) command.push(`-c="${config}"`);
-        if (header) command.push(`--header="${header}"`);
-        if (endpoint) command.push(`--endpoint="${endpoint}"`);
-        if (tag) command.push(`-t="${tag}"`);
-        if (skipSSLValidation) command.push(`--skipSSLValidation`);
-        if (key) command.push(`--key="${key}"`);
-
-        console.log(`[${this.id}] Downloading schema`);
-        this.execCommand(command.join(' '), `[${this.id}] Schema downloaded`);
+        return hasChanged;
     }
 
     apply(compiler) {
-        compiler.hooks.afterPlugins.tap(this.id, this.fetchSchema);
-        compiler.hooks.run.tap(this.id, this.genTypes);
-        compiler.hooks.watchRun.tap(this.id, this.genTypes);
+        const run = compilation => {
+            const hasChanged = this.hasChanged(compilation);
+
+            if (!hasChanged) return Promise.resolve();
+
+            if (!this.schemaFetched) {
+                return fetchSchema(this.options).then(() => {
+                    this.schemaFetched = true;
+                    genTypes(this.options);
+                });
+            }
+
+            return genTypes(this.options);
+        };
+
+        compiler.hooks.beforeRun.tapPromise(this.id, run);
+        compiler.hooks.watchRun.tapPromise(this.id, run);
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,7 +1022,7 @@ apollo-utilities@^1.2.1:
     ts-invariant "^0.2.1"
     tslib "^1.9.3"
 
-apollo@^2.6.2:
+apollo@^2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/apollo/-/apollo-2.8.3.tgz#ebb12e059cc3727185a8db8a926590e95982a469"
   integrity sha512-qYC2T7qtfGhwd+4KaYzUEC9u8Ag9vLY+SKDf0B0wHedVCz3qDXaw3mzu4p8VJCOUUmRPt0eGfbRYw/zsrxQGCw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,6 +1736,11 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-spinners@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.1.0.tgz#22c34b4d51f573240885b201efda4e4ec9fff3c7"
+  integrity sha512-8B00fJOEh1HPrx4fo5eW16XmE1PcL1tGpGrxy63CXGP9nHdPBN63X75hA1zhvQuhVztJWLqV58Roj2qlNM7cAA==
+
 cli-truncate@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
@@ -1816,6 +1821,11 @@ clone-response@1.0.2:
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 co@^4.6.0:
   version "4.6.0"
@@ -2182,6 +2192,13 @@ default-require-extensions@^2.0.0:
   integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
   dependencies:
     strip-bom "^3.0.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -4542,6 +4559,13 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
@@ -4949,7 +4973,7 @@ no-case@^2.2.0, no-case@^2.3.2:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0:
+node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
@@ -5221,6 +5245,18 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+ora@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
+  dependencies:
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-spinners "^2.0.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
 
 original@^1.0.0:
   version "1.0.2"
@@ -6525,7 +6561,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -7088,6 +7124,13 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
resolves #2 

Codegen and schema downloads both are synchronous now to avoid getting race conditions with the actual compilation. Which gave false positives on compiles.

Performance is increased by a lot because the npx implementation was removed in favor of installing apollo as a dependency.

Also added a nice spinner.